### PR TITLE
Forms DELETE request

### DIFF
--- a/backend/src/main/java/com/google/step/data/Form.java
+++ b/backend/src/main/java/com/google/step/data/Form.java
@@ -25,7 +25,7 @@ import java.util.Date;
  * This class represents a Form and all of its data. Supports conversion to datastore Entity objects
  * and back.
  */
-public class Form {
+public final class Form {
 
   private Date date;
   private long formId;

--- a/backend/src/main/java/com/google/step/data/Form.java
+++ b/backend/src/main/java/com/google/step/data/Form.java
@@ -17,6 +17,8 @@ package com.google.step.data;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.users.User;
+import com.google.step.utils.AdvertiserUtil;
 import java.util.Date;
 
 /**
@@ -89,6 +91,10 @@ public class Form {
     formEntity.setProperty("googleKey", googleKey);
     formEntity.setProperty("verified", verified);
     return formEntity;
+  }
+
+  public static Key getFormKeyFromUserAndFormId(User user, long formId) {
+    return KeyFactory.createKey(AdvertiserUtil.createAdvertiserKey(user), "Form", formId);
   }
 
 }

--- a/backend/src/main/java/com/google/step/filters/ClientAppFilter.java
+++ b/backend/src/main/java/com/google/step/filters/ClientAppFilter.java
@@ -18,7 +18,7 @@ import javax.servlet.http.HttpServletResponse;
  * Filters any Angular routing URLs from requests made by Angular app.
  */
 @WebFilter("/*")
-public class ClientAppFilter implements Filter {
+public final class ClientAppFilter implements Filter {
 
   @Override
   public void init(FilterConfig filterConfig) {

--- a/backend/src/main/java/com/google/step/servlets/FormsServlet.java
+++ b/backend/src/main/java/com/google/step/servlets/FormsServlet.java
@@ -20,6 +20,8 @@ import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.CompositeFilterOperator;
+import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.users.User;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -49,8 +51,7 @@ public class FormsServlet extends HttpServlet {
 
   /**
    * Deletes the form specified by the form_id specified in the request headers or a url parameter.
-   * Returns a 204 No Content status code on a successful deletion.
-   * Authentication required.
+   * Returns a 204 No Content status code on a successful deletion. Authentication required.
    *
    * @param request  the HTTP Request
    * @param response the HTTP Response
@@ -113,8 +114,8 @@ public class FormsServlet extends HttpServlet {
    * JSON.stringify({ form_id: "1234", form_name: "exampleForm" }), headers: { 'Content-type':
    * 'application/json; charset=UTF-8' } }) .then(res => res.json()) .then(console.log)
    * <p>
-   * Note: form_id should be a string not a number without quotation marks.
-   * Authentication required.
+   * Note: form_id should be a string not a number without quotation marks. Authentication
+   * required.
    *
    * @param request  the HTTP Request. Expecting parameter form_id with the form_id to add
    * @param response the HTTP Response
@@ -147,8 +148,8 @@ public class FormsServlet extends HttpServlet {
     //query the datastore to see if the form id already is claimed
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Query query = new Query("Form")
-        .setFilter(new Query.FilterPredicate("formId", Query.FilterOperator.EQUAL, formId))
-        .setFilter(new Query.FilterPredicate("verified", Query.FilterOperator.EQUAL, true))
+        .setFilter(CompositeFilterOperator.and(FilterOperator.EQUAL.of("formId", formId),
+            FilterOperator.EQUAL.of("verified", true)))
         .setKeysOnly();
     PreparedQuery queryResults = datastore.prepare(query);
     if (!queryResults.asList(FetchOptions.Builder.withDefaults())

--- a/backend/src/main/java/com/google/step/servlets/FormsServlet.java
+++ b/backend/src/main/java/com/google/step/servlets/FormsServlet.java
@@ -43,7 +43,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @WebServlet("/api/forms")
-public class FormsServlet extends HttpServlet {
+public final class FormsServlet extends HttpServlet {
 
   private static final String ID_URL_PARAM = "id";
   private final char[] alphanumerics = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"

--- a/backend/src/main/java/com/google/step/servlets/FormsServlet.java
+++ b/backend/src/main/java/com/google/step/servlets/FormsServlet.java
@@ -44,11 +44,38 @@ import javax.servlet.http.HttpServletResponse;
 public class FormsServlet extends HttpServlet {
 
   private static final String ID_URL_PARAM = "id";
-  private char[] alphanumerics = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+  private final char[] alphanumerics = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
       .toCharArray();
 
   /**
+   * Deletes the form specified by the form_id specified in the request headers or a url parameter.
+   * Returns a 204 No Content status code on a successful deletion.
+   * Authentication required.
+   *
+   * @param request  the HTTP Request
+   * @param response the HTTP Response
+   */
+  @Override
+  public void doDelete(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+
+    if (!UserAuthenticationUtil.isAuthenticated()) {
+      response.sendRedirect("/");
+      return;
+    }
+
+    long formId = Long.parseLong(request.getParameter("form_id"));
+    User user = UserAuthenticationUtil.getCurrentUser();
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.delete(Form.getFormKeyFromUserAndFormId(user, formId));
+
+    response.setStatus(204); //Success - 204 No Content
+  }
+
+  /**
    * Returns JSON representing the advertiser's unique webhook and all their Form data.
+   * Authentication required.
    *
    * @param request  the HTTP Request
    * @param response the HTTP Response
@@ -87,6 +114,7 @@ public class FormsServlet extends HttpServlet {
    * 'application/json; charset=UTF-8' } }) .then(res => res.json()) .then(console.log)
    * <p>
    * Note: form_id should be a string not a number without quotation marks.
+   * Authentication required.
    *
    * @param request  the HTTP Request. Expecting parameter form_id with the form_id to add
    * @param response the HTTP Response
@@ -178,17 +206,17 @@ public class FormsServlet extends HttpServlet {
     /**
      * Webhook URL for Advertiser to put in Google Ads.
      */
-    private String webhookUrl;
+    private final String webhookUrl;
 
     /**
      * Randomly generated Google Key
      */
-    private String googleKey;
+    private final String googleKey;
 
     /**
      * The id of the form
      */
-    private long formId;
+    private final long formId;
 
     /**
      * Constructor for response to send back to user containing the webhook and google key
@@ -218,12 +246,12 @@ public class FormsServlet extends HttpServlet {
     /**
      * Webhook URL for Advertiser to put in Google Ads.
      */
-    private String webhookUrl;
+    private final String webhookUrl;
 
     /**
      * List of the User's forms
      */
-    private List<Form> forms;
+    private final List<Form> forms;
 
     /**
      * Constructor for response to send back to user containing the webhook

--- a/backend/src/main/java/com/google/step/servlets/FormsServlet.java
+++ b/backend/src/main/java/com/google/step/servlets/FormsServlet.java
@@ -150,6 +150,8 @@ public class FormsServlet extends HttpServlet {
   /**
    * Deletes the form specified by the form_id specified in the request headers or a url parameter.
    * Returns a 204 No Content status code on a successful deletion. Authentication required.
+   * Note: returns 204 No Content even if the form to be deleted never existed in the first place.
+   * Instead, guarantees that it doesn't exist anymore in the datastore.
    *
    * @param request  the HTTP Request
    * @param response the HTTP Response

--- a/backend/src/main/java/com/google/step/servlets/FormsServlet.java
+++ b/backend/src/main/java/com/google/step/servlets/FormsServlet.java
@@ -50,31 +50,6 @@ public class FormsServlet extends HttpServlet {
       .toCharArray();
 
   /**
-   * Deletes the form specified by the form_id specified in the request headers or a url parameter.
-   * Returns a 204 No Content status code on a successful deletion. Authentication required.
-   *
-   * @param request  the HTTP Request
-   * @param response the HTTP Response
-   */
-  @Override
-  public void doDelete(HttpServletRequest request, HttpServletResponse response)
-      throws IOException {
-
-    if (!UserAuthenticationUtil.isAuthenticated()) {
-      response.sendRedirect("/");
-      return;
-    }
-
-    long formId = Long.parseLong(request.getParameter("form_id"));
-    User user = UserAuthenticationUtil.getCurrentUser();
-
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    datastore.delete(Form.getFormKeyFromUserAndFormId(user, formId));
-
-    response.setStatus(204); //Success - 204 No Content
-  }
-
-  /**
    * Returns JSON representing the advertiser's unique webhook and all their Form data.
    * Authentication required.
    *
@@ -170,6 +145,31 @@ public class FormsServlet extends HttpServlet {
 
     response.setContentType("application/json;");
     response.getWriter().println(new WebhookResponse(webhookUrl, googleKey, formId).toJson());
+  }
+
+  /**
+   * Deletes the form specified by the form_id specified in the request headers or a url parameter.
+   * Returns a 204 No Content status code on a successful deletion. Authentication required.
+   *
+   * @param request  the HTTP Request
+   * @param response the HTTP Response
+   */
+  @Override
+  public void doDelete(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+
+    if (!UserAuthenticationUtil.isAuthenticated()) {
+      response.sendRedirect("/");
+      return;
+    }
+
+    long formId = Long.parseLong(request.getParameter("form_id"));
+    User user = UserAuthenticationUtil.getCurrentUser();
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.delete(Form.getFormKeyFromUserAndFormId(user, formId));
+
+    response.setStatus(204); //Success - 204 No Content
   }
 
   /**

--- a/backend/src/main/java/com/google/step/servlets/LeadsServlet.java
+++ b/backend/src/main/java/com/google/step/servlets/LeadsServlet.java
@@ -37,7 +37,7 @@ import javax.servlet.http.HttpServletResponse;
  * Handles GET request to return Lead data in JSON to the client.
  */
 @WebServlet("/api/leads")
-public class LeadsServlet extends HttpServlet {
+public final class LeadsServlet extends HttpServlet {
 
   private static final Gson gson = new GsonBuilder()
       .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)

--- a/backend/src/main/java/com/google/step/servlets/LoginServlet.java
+++ b/backend/src/main/java/com/google/step/servlets/LoginServlet.java
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
  * Servlet to check if user is logged in and return corresponding URL for logging in/out.
  */
 @WebServlet("/api/login")
-public class LoginServlet extends HttpServlet {
+public final class LoginServlet extends HttpServlet {
 
   /**
    * Checks state of user in this class.

--- a/backend/src/main/java/com/google/step/servlets/WebhookServlet.java
+++ b/backend/src/main/java/com/google/step/servlets/WebhookServlet.java
@@ -38,7 +38,7 @@ import javax.servlet.http.HttpServletResponse;
  * requests with JSON with lead data.
  */
 @WebServlet("/api/webhook")
-public class WebhookServlet extends HttpServlet {
+public final class WebhookServlet extends HttpServlet {
 
   private static final Gson gson = new GsonBuilder()
       .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)


### PR DESCRIPTION
# Description

Implements the DELETE request for the api/forms endpoint. Allows advertisers to "delete" or unlink a form. Currently, this just deletes the form object associated with the form_id under their advertiser entity that they want to delete (does not delete leads associated with that form -> don't think we want this).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Manually on a local development server

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
