### PR TITLE
fix(crm/leads): Register Paginator and Sort on `AfterViewInit`

### DIFF
--- a/frontend/src/app/crm/leads/leads.component.html
+++ b/frontend/src/app/crm/leads/leads.component.html
@@ -1,65 +1,85 @@
-
 <p>leads works!</p>
 <li *ngFor="let lead of leads">
-  <p>{{lead.date}}, {{lead.lead_id}}, {{lead.campaign_id}}, {{lead.gcl_id}}, {{lead.api_version}}, {{lead.form_id}}, {{lead.google_key}}, {{lead.column_data.FULL_NAME}}, {{lead.column_data.PHONE_NUMBER}}, {{lead.is_test}}, {{lead.adgroup_id}}, {{lead.creative_id}}</p>
+  <p>{{lead.date}}, {{lead.lead_id}}, {{lead.campaign_id}}, {{lead.gcl_id}}, {{lead.api_version}}, {{lead.form_id}},
+    {{lead.google_key}}, {{lead.column_data.FULL_NAME}}, {{lead.column_data.PHONE_NUMBER}}, {{lead.is_test}},
+    {{lead.adgroup_id}}, {{lead.creative_id}}</p>
 </li>
 
 <div class="container">
-<div class="mat-elevation-z8">
+  <div class="mat-elevation-z8">
 
-  <mat-form-field>
-    <mat-label>Filter</mat-label>
-    <input matInput (keyup)="applyFilter($event)" placeholder="Ex. ium" #input>
-  </mat-form-field>
+    <mat-form-field>
+      <mat-label>Filter</mat-label>
+      <input matInput
+             (change)="applyFilter($event)"
+             placeholder="Ex. ium"
+             #input>
+    </mat-form-field>
 
-  <mat-table [dataSource]="dataSource" matSort  cdkFocusInitial class="mat-elevation-z8">
+    <mat-table [dataSource]="dataSource"
+               matSort
+               cdkFocusInitial
+               class="mat-elevation-z8">
 
-    <!-- Lead Id Column -->
-    <ng-container matColumnDef="lead_id">
-      <mat-header-cell *matHeaderCellDef mat-sort-header> ID </mat-header-cell>
-      <mat-cell *matCellDef="let lead"> {{lead.lead_id}} </mat-cell>
-    </ng-container>
+      <!-- Lead Id Column -->
+      <ng-container matColumnDef="lead_id">
+        <mat-header-cell *matHeaderCellDef
+                         mat-sort-header> ID </mat-header-cell>
+        <mat-cell *matCellDef="let lead"> {{lead.lead_id}} </mat-cell>
+      </ng-container>
 
-    <!-- Name Column -->
-    <ng-container matColumnDef="name" >
-      <mat-header-cell *matHeaderCellDef mat-sort-header> Name </mat-header-cell>
-      <mat-cell *matCellDef="let lead"> {{lead.column_data.FULL_NAME}} </mat-cell>
-    </ng-container>
+      <!-- Name Column -->
+      <ng-container matColumnDef="name">
+        <mat-header-cell *matHeaderCellDef
+                         mat-sort-header> Name </mat-header-cell>
+        <mat-cell *matCellDef="let lead"> {{lead.column_data.FULL_NAME}} </mat-cell>
+      </ng-container>
 
-    <!-- Phone Number Column -->
-    <ng-container matColumnDef="phone_number">
-      <mat-header-cell *matHeaderCellDef mat-sort-header> Phone Number </mat-header-cell>
-      <mat-cell *matCellDef="let lead"> {{lead.column_data.PHONE_NUMBER}} </mat-cell>
-    </ng-container>
+      <!-- Phone Number Column -->
+      <ng-container matColumnDef="phone_number">
+        <mat-header-cell *matHeaderCellDef
+                         mat-sort-header> Phone Number </mat-header-cell>
+        <mat-cell *matCellDef="let lead"> {{lead.column_data.PHONE_NUMBER}} </mat-cell>
+      </ng-container>
 
-    <!-- Campaign Id Column -->
-    <ng-container matColumnDef="campaign_id" >
-      <mat-header-cell *matHeaderCellDef mat-sort-header> Campaign Id </mat-header-cell>
-      <mat-cell *matCellDef="let lead"> {{lead.campaign_id}} </mat-cell>
-    </ng-container>
+      <!-- Campaign Id Column -->
+      <ng-container matColumnDef="campaign_id">
+        <mat-header-cell *matHeaderCellDef
+                         mat-sort-header> Campaign Id </mat-header-cell>
+        <mat-cell *matCellDef="let lead"> {{lead.campaign_id}} </mat-cell>
+      </ng-container>
 
-    <!-- Date Column -->
-    <ng-container matColumnDef="date" >
-      <mat-header-cell *matHeaderCellDef mat-sort-header> Date </mat-header-cell>
-      <mat-cell *matCellDef="let lead"> {{lead.date}} </mat-cell>
-    </ng-container>
+      <!-- Date Column -->
+      <ng-container matColumnDef="date">
+        <mat-header-cell *matHeaderCellDef
+                         mat-sort-header> Date </mat-header-cell>
+        <mat-cell *matCellDef="let lead"> {{lead.date}} </mat-cell>
+      </ng-container>
 
-    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
-    <!-- Row shown when there is no matching data. -->
-    <mat-header-row class="mat-row" *matNoDataRow>
-      <mat-row class="mat-cell" colspan="4">No data matching the filter "{{input.value}}"</mat-row>
-    </mat-header-row>
-  </mat-table>
-  <mat-card *ngIf="isLoading" style="display: flex; justify-content: center; align-items: center">
-    <mat-progress-spinner
-      color="primary"
-      mode="indeterminate">
-    </mat-progress-spinner>
-  </mat-card>
- <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+      <!-- Row shown when there is no matching data. -->
+      <mat-header-row class="mat-row"
+                      *matNoDataRow>
+        <mat-row class="mat-cell"
+                 colspan="4">No data matching the filter "{{input.value}}"</mat-row>
+      </mat-header-row>
+    </mat-table>
+
+    <!-- TODO: Switch this to use a class instead of setting styles -->
+
+    <mat-card *ngIf="isLoading | async"
+              [style.display]="flex"
+              [style.justify-content]="center"
+              [style.align-items]="center">
+      <mat-progress-spinner color="primary"
+                            mode="indeterminate">
+      </mat-progress-spinner>
+    </mat-card>
+    <mat-paginator [pageSizeOptions]="[5, 10, 20]"
+                   showFirstLastButtons></mat-paginator>
 
 
-</div>
+  </div>
 
 </div>

--- a/frontend/src/app/crm/leads/leads.component.ts
+++ b/frontend/src/app/crm/leads/leads.component.ts
@@ -1,60 +1,61 @@
-import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
+import {AfterViewInit, AfterViewInit, Component, OnInit, ViewChild} from '@angular/core';
+import {MatPaginator} from '@angular/material/paginator';
+import {MatSort} from '@angular/material/sort';
+import {MatTableDataSource} from '@angular/material/table';
+import {BehaviorSubject} from 'rxjs';
+import {first} from 'rxjs/operators';
 
-import { LeadService } from '../../services/lead.service';
-
-import { Lead } from '../../models/lead.model';
-
-//Material imports
-import { MatTableDataSource } from '@angular/material/table';
-import { MatPaginator } from '@angular/material/paginator';
-import { MatSort } from '@angular/material/sort';
-
-import {delay} from 'rxjs/operators';
+import {Lead} from '../../models/lead.model';
+import {LeadService} from '../../services/lead.service';
 
 @Component({
   selector: 'app-leads',
   templateUrl: './leads.component.html',
   styleUrls: ['./leads.component.css']
 })
-export class LeadsComponent implements OnInit {
-    //Creates an array of Leads
-   leads : Lead[];
+export class LeadsComponent implements AfterViewInit {
+  leads: Lead[];
 
-    //Initiating dataSource for tabulating the fetched JSON
-   displayedColumns = ['lead_id','name', 'phone_number', 'campaign_id', 'date'];
-   dataSource : MatTableDataSource<Lead>;
-   isLoading = true;
+  readonly isLoading$ = new BehaviorSubject<boolean>(true);
+  readonly dataSource: MatTableDataSource<Lead>;
+  readonly displayedColumns: string[] = [
+    'lead_id',
+    'name',
+    'phone_number',
+    'campaign_id',
+    'date',
+  ];
 
-   @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
-   @ViewChild(MatSort, {static: true}) sort: MatSort;
+  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
+  @ViewChild(MatSort, {static: true}) sort: MatSort;
 
-   constructor(private leadService : LeadService) { }
+  constructor(private readonly leadService: LeadService) {
+    this.dataSource = new MatTableDataSource();
 
-   ngOnInit() : void {
-      delay(20000);
-      this.getAllLeads();
-      this.isLoading = false;
-   }
+    this.loadAllLeads();
+  }
 
-   getAllLeads(): void {
-     this.leadService.getAllLeads()
-     .subscribe((leads) => {
-       this.dataSource = new MatTableDataSource(leads);
-       this.dataSource.paginator = this.paginator;
-       this.dataSource.sort = this.sort;
-      } );
-   }
-   applyFilter(event: Event) {
-      //console.log(this.dataSource);
-           console.log("Hello1")
-          const filterValue = (event.target as HTMLInputElement).value;
-          this.dataSource.filter = filterValue.trim().toLowerCase();
-       console.log("Hello2")
-          if (this.dataSource.paginator) {
-             console.log("Hello3")
-            this.dataSource.paginator.firstPage();
-          }
-   }
+  ngAfterViewInit(): void {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+  }
 
-
+  loadAllLeads(): void {
+    this.isLoading$.next(true);
+    this.leadService.getAllLeads().pipe(first()).subscribe((leads) => {
+      this.dataSource.data = leads;
+      this.isLoading$.next(false);
+    });
+  }
+  applyFilter(event: Event) {
+    // console.log(this.dataSource);
+    console.log('Hello1')
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+    console.log('Hello2')
+    if (this.dataSource.paginator != null) {
+      console.log('Hello3');
+      this.dataSource.paginator.firstPage();
+    }
+  }
 }


### PR DESCRIPTION
# Description

Fixes the filter input by creating a persistent TableDataSource and registering the pagination and sort components once the view initializes. Since they may not exist in `ngOnInit`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is has not been tested

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
