### PR TITLE
Alex/verify lead

### DIFF
--- a/backend/src/main/java/com/google/minicrm/data/Lead.java
+++ b/backend/src/main/java/com/google/minicrm/data/Lead.java
@@ -149,7 +149,7 @@ public final class Lead implements DatastoreObject {
    * @param leadId    the id of the lead
    * @return          a key for thelead specified by the parentKey and leadId given
    */
-  public Key generateKey(Key parentKey, String leadId) {
+  public static Key generateKey(Key parentKey, String leadId) {
     return KeyFactory.createKey(parentKey, KIND_NAME, leadId);
   }
 

--- a/backend/src/main/java/com/google/minicrm/data/Lead.java
+++ b/backend/src/main/java/com/google/minicrm/data/Lead.java
@@ -16,6 +16,7 @@ package com.google.minicrm.data;
 
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -125,7 +126,7 @@ public final class Lead implements DatastoreObject {
    * @return this lead object represented as an Entity
    */
   public Entity asEntity() {
-    Entity leadEntity = new Entity(KIND_NAME, advertiserKey);
+    Entity leadEntity = new Entity(generateKey(advertiserKey, leadId));
     leadEntity.setProperty("date", date);
     leadEntity.setProperty("leadId", leadId);
     leadEntity.setProperty("campaignId", campaignId);
@@ -140,6 +141,16 @@ public final class Lead implements DatastoreObject {
       leadEntity.setProperty(key, columnData.get(key));
     }
     return leadEntity;
+  }
+
+  /**
+   * Generates a datastore key for the lead specified by the parent advertiser key and lead id given
+   * @param parentKey the key for the advertiser entity that owns this lead
+   * @param leadId    the id of the lead
+   * @return          a key for thelead specified by the parentKey and leadId given
+   */
+  public Key generateKey(Key parentKey, String leadId) {
+    return KeyFactory.createKey(parentKey, KIND_NAME, leadId);
   }
 
   /**

--- a/backend/src/main/java/com/google/minicrm/servlets/WebhookServlet.java
+++ b/backend/src/main/java/com/google/minicrm/servlets/WebhookServlet.java
@@ -132,7 +132,6 @@ public final class WebhookServlet extends HttpServlet {
       return;
     }
 
-
     //check if this lead belongs to a new form, if it does make a new form entity
     Key formKey = Form.generateKey(advertiserKey, newLead.getFormId());
     try {

--- a/backend/src/main/java/com/google/minicrm/servlets/WebhookServlet.java
+++ b/backend/src/main/java/com/google/minicrm/servlets/WebhookServlet.java
@@ -27,6 +27,7 @@ import com.google.minicrm.data.Advertiser;
 import com.google.minicrm.data.Form;
 import com.google.minicrm.data.Lead;
 import com.google.minicrm.interfaces.ClientResponse;
+import com.google.minicrm.utils.DatastoreUtil;
 import com.google.minicrm.utils.EmailUtil;
 import com.google.minicrm.utils.UserAuthenticationUtil;
 import java.io.IOException;
@@ -93,6 +94,7 @@ public final class WebhookServlet extends HttpServlet {
    * - 401 Unauthorized: if the advertiser's google key and the lead's google key do not match
    * - 404 Not Found: if the id parameter is not specified or blank or if the id specified is not
    *                  valid
+   * - 409 Conflict: if the lead sent already has been successfully sent
    *
    * @param request  the HTTP Request
    * @param response the HTTP Response
@@ -124,7 +126,11 @@ public final class WebhookServlet extends HttpServlet {
     }
 
     //de-duplicate the lead
-
+    Key leadKey = Lead.generateKey(advertiserKey, newLead.getLeadId());
+    if (DatastoreUtil.exists(leadKey)) {
+      response.sendError(409, "This lead already has been successfully sent and exists.");
+      return;
+    }
 
 
     //check if this lead belongs to a new form, if it does make a new form entity

--- a/backend/src/main/java/com/google/minicrm/servlets/WebhookServlet.java
+++ b/backend/src/main/java/com/google/minicrm/servlets/WebhookServlet.java
@@ -90,6 +90,7 @@ public final class WebhookServlet extends HttpServlet {
    *
    * HTTP Response Status Codes:
    * - 200 OK: success
+   * - 401 Unauthorized: if the advertiser's google key and the lead's google key do not match
    * - 404 Not Found: if the id parameter is not specified or blank or if the id specified is not
    *                  valid
    *
@@ -116,7 +117,14 @@ public final class WebhookServlet extends HttpServlet {
     }
     Lead newLead = Lead.fromReader(request.getReader(), advertiserKey);
 
-    //verify the lead
+    //verify the lead - has correct google key for this advertiser
+    if (!newLead.getGoogleKey().equals(advertiser.getGoogleKey())) {
+      response.sendError(401, "The provided Google Key and webhook do not match.");
+      return;
+    }
+
+    //de-duplicate the lead
+
 
 
     //check if this lead belongs to a new form, if it does make a new form entity


### PR DESCRIPTION
# Description

Incoming leads to api/webhook are now verified by google key and made sure they already are not received
- On bad google key - returns 401 unauthorized
- On duplicate lead (lead already exists) - returns 409 Conflict

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Manually in local development server

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
