### PR TITLE
Move webhook and key

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -9,7 +9,4 @@ export class AppComponent {
 
   constructor() { }
 
-  ngOnInit() {
-  }
-
 }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -23,8 +23,8 @@ import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatListModule } from '@angular/material/list';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 // Routing
 import { AppRoutingModule } from './app-routing.module';
@@ -41,6 +41,7 @@ import { AnalyticsComponent } from './components/crm/analytics/analytics.compone
 import { LandingComponent } from './components/landing/landing.component';
 import { CrmTableComponent } from './components/shared/crm-table/crm-table.component';
 import { LinkFormDialogComponent } from './components/crm/forms/link-form-dialog/link-form-dialog.component';
+import { CopyableFormFieldComponent } from './components/shared/copyable-form-field/copyable-form-field.component';
 
 @NgModule({
   declarations: [
@@ -54,7 +55,8 @@ import { LinkFormDialogComponent } from './components/crm/forms/link-form-dialog
     LandingComponent,
     FormsComponent,
     CrmTableComponent,
-    LinkFormDialogComponent
+    LinkFormDialogComponent,
+    CopyableFormFieldComponent
   ],
   imports: [
     HttpClientModule,
@@ -84,7 +86,8 @@ import { LinkFormDialogComponent } from './components/crm/forms/link-form-dialog
     MatCheckboxModule,
     MatDialogModule,
     MatListModule,
-    MatMenuModule
+    MatMenuModule,
+    MatTooltipModule
    ],
   providers: [
     { provide: LocationStrategy, useClass: PathLocationStrategy }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -18,11 +18,13 @@ import { ClipboardModule } from '@angular/cdk/clipboard';
 import { MatSortModule } from '@angular/material/sort';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatListModule } from '@angular/material/list';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule } from '@angular/material/menu';
 
 // Routing
 import { AppRoutingModule } from './app-routing.module';
@@ -81,7 +83,8 @@ import { LinkFormDialogComponent } from './components/crm/forms/link-form-dialog
     MatCardModule,
     MatCheckboxModule,
     MatDialogModule,
-    MatListModule
+    MatListModule,
+    MatMenuModule
    ],
   providers: [
     { provide: LocationStrategy, useClass: PathLocationStrategy }

--- a/frontend/src/app/components/crm/analytics/analytics.component.ts
+++ b/frontend/src/app/components/crm/analytics/analytics.component.ts
@@ -9,7 +9,7 @@ import { Title } from '@angular/platform-browser';
 export class AnalyticsComponent implements OnInit {
 
   constructor(private titleService: Title) {
-    this.titleService.setTitle('Analytics')
+    this.titleService.setTitle('Analytics');
   }
 
   ngOnInit(): void {

--- a/frontend/src/app/components/crm/crm.component.css
+++ b/frontend/src/app/components/crm/crm.component.css
@@ -11,4 +11,5 @@
 
 #menuContainer {
     padding: 16px;
+    padding-bottom: 8px;
 }

--- a/frontend/src/app/components/crm/crm.component.css
+++ b/frontend/src/app/components/crm/crm.component.css
@@ -8,3 +8,7 @@
 .spacer {
     flex: 1 1 auto;
 }
+
+#menuContainer {
+    padding: 16px;
+}

--- a/frontend/src/app/components/crm/crm.component.html
+++ b/frontend/src/app/components/crm/crm.component.html
@@ -33,9 +33,26 @@
       <mat-toolbar-row>
         <span>{{ titleService.getTitle() }}</span>
         <span class="spacer"></span>
-        <button mat-flat-button (click)="logout()">
-          LOGOUT
+        <button mat-icon-button [matMenuTriggerFor]="beforeMenu">
+          <mat-icon>account_circle</mat-icon>
         </button>
+        <mat-menu #beforeMenu="matMenu" xPosition="before">
+          <mat-form-field appearance="outline" floatLabel="always">
+            <mat-label>Your Webhook</mat-label>
+              <input matInput readonly="true" type="url" [value]="webhookUrl">
+              <button mat-icon-button matSuffix [cdkCopyToClipboard]="webhookUrl" matTooltip="Copied">
+                <mat-icon>content_copy</mat-icon>
+              </button>
+          </mat-form-field>
+          <mat-form-field appearance="outline" floatLabel="always">
+              <mat-label>Your Google Key</mat-label>
+              <input matInput readonly="true" type="url" [value]="googleKey">
+              <button mat-icon-button matSuffix [cdkCopyToClipboard]="googleKey" matTooltip="Copied">
+                  <mat-icon>content_copy</mat-icon>
+              </button>
+          </mat-form-field>
+          <button mat-flat-button color="primary" (click)="logout()">LOGOUT</button>
+        </mat-menu>
       </mat-toolbar-row>
     </mat-toolbar>
     <router-outlet></router-outlet>

--- a/frontend/src/app/components/crm/crm.component.html
+++ b/frontend/src/app/components/crm/crm.component.html
@@ -37,21 +37,23 @@
           <mat-icon>account_circle</mat-icon>
         </button>
         <mat-menu #beforeMenu="matMenu" xPosition="before">
-          <mat-form-field appearance="outline" floatLabel="always">
-            <mat-label>Your Webhook</mat-label>
-              <input matInput readonly="true" type="url" [value]="webhookUrl">
-              <button mat-icon-button matSuffix [cdkCopyToClipboard]="webhookUrl" matTooltip="Copied">
-                <mat-icon>content_copy</mat-icon>
-              </button>
-          </mat-form-field>
-          <mat-form-field appearance="outline" floatLabel="always">
-              <mat-label>Your Google Key</mat-label>
-              <input matInput readonly="true" type="url" [value]="googleKey">
-              <button mat-icon-button matSuffix [cdkCopyToClipboard]="googleKey" matTooltip="Copied">
+          <div id="menuContainer" fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="16px" (click)="$event.stopPropagation();">
+            <mat-form-field appearance="outline" floatLabel="always">
+              <mat-label>Your Webhook</mat-label>
+                <input matInput readonly="true" type="url" [value]="webhookUrl">
+                <button mat-icon-button matSuffix [cdkCopyToClipboard]="webhookUrl" matTooltip="Copied">
                   <mat-icon>content_copy</mat-icon>
-              </button>
-          </mat-form-field>
-          <button mat-flat-button color="primary" (click)="logout()">LOGOUT</button>
+                </button>
+            </mat-form-field>
+            <mat-form-field appearance="outline" floatLabel="always">
+                <mat-label>Your Google Key</mat-label>
+                <input matInput readonly="true" type="url" [value]="googleKey">
+                <button mat-icon-button matSuffix [cdkCopyToClipboard]="googleKey" matTooltip="Copied">
+                    <mat-icon>content_copy</mat-icon>
+                </button>
+            </mat-form-field>
+            <button mat-flat-button color="primary" (click)="logout()">LOGOUT</button>
+          </div>
         </mat-menu>
       </mat-toolbar-row>
     </mat-toolbar>

--- a/frontend/src/app/components/crm/crm.component.html
+++ b/frontend/src/app/components/crm/crm.component.html
@@ -38,20 +38,8 @@
         </button>
         <mat-menu #beforeMenu="matMenu" xPosition="before">
           <div id="menuContainer" fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="16px" (click)="$event.stopPropagation();">
-            <mat-form-field appearance="outline" floatLabel="always">
-              <mat-label>Your Webhook</mat-label>
-                <input matInput readonly="true" type="url" [value]="webhookUrl">
-                <button mat-icon-button matSuffix [cdkCopyToClipboard]="webhookUrl" matTooltip="Copied">
-                  <mat-icon>content_copy</mat-icon>
-                </button>
-            </mat-form-field>
-            <mat-form-field appearance="outline" floatLabel="always">
-                <mat-label>Your Google Key</mat-label>
-                <input matInput readonly="true" type="url" [value]="googleKey">
-                <button mat-icon-button matSuffix [cdkCopyToClipboard]="googleKey" matTooltip="Copied">
-                    <mat-icon>content_copy</mat-icon>
-                </button>
-            </mat-form-field>
+            <app-copyable-form-field label="Your Webhook" [copyableValue]="webhookUrl"></app-copyable-form-field>
+            <app-copyable-form-field label="Your Google Key" [copyableValue]="googleKey"></app-copyable-form-field>
             <button mat-flat-button color="primary" (click)="logout()">LOGOUT</button>
           </div>
         </mat-menu>

--- a/frontend/src/app/components/crm/crm.component.ts
+++ b/frontend/src/app/components/crm/crm.component.ts
@@ -2,14 +2,15 @@ import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { LoginService } from 'src/app/services/login.service';
 import { LoginResponse } from 'src/app/models/server_responses/login-response.model';
-
+import { WebhookService } from 'src/app/services/webhook.service';
+import { WebHookResponse } from 'src/app/models/server_responses/webhook-response.model';
 @Component({
   selector: 'app-crm',
   templateUrl: './crm.component.html',
   styleUrls: ['./crm.component.css']
 })
 export class CrmComponent implements OnInit {
-  isExpanded: boolean = true;
+  isExpanded = true;
   navigationData: NavigationDatum[] = [
     {
       displayedName: 'Guide',
@@ -42,15 +43,21 @@ export class CrmComponent implements OnInit {
       icon: 'settings'
     }
   ];
-  logoutUrl: string = '/';
+  logoutUrl = '/';
+  webhookUrl = '';
+  googleKey = '';
 
-  constructor(public titleService: Title, private loginService: LoginService) {
+  constructor(public titleService: Title, private loginService: LoginService, private webhookService: WebhookService) {
     this.loginService.getLoginResponse().subscribe((res: LoginResponse) => {
-      if(!res.loggedIn) {
+      if (!res.loggedIn) {
         location.href = this.logoutUrl;
       } else {
         this.logoutUrl = res.url;
       }
+    });
+    this.webhookService.getWebhook().subscribe((res: WebHookResponse) => {
+      this.webhookUrl = res.webhookUrl;
+      this.googleKey = res.googleKey;
     });
   }
 

--- a/frontend/src/app/components/crm/forms/forms.component.html
+++ b/frontend/src/app/components/crm/forms/forms.component.html
@@ -8,20 +8,6 @@
                 <mat-icon>search</mat-icon>
             </button>
         </mat-form-field>
-        <mat-form-field appearance="outline" floatLabel="always">
-            <mat-label>Your Webhook</mat-label>
-            <input matInput readonly="true" type="url" [value]="webhookUrl">
-            <button mat-icon-button matSuffix [cdkCopyToClipboard]="webhookUrl">
-                <mat-icon>content_copy</mat-icon>
-            </button>
-        </mat-form-field>
-        <mat-form-field appearance="outline" floatLabel="always">
-            <mat-label>Your Google Key</mat-label>
-            <input matInput readonly="true" type="url" [value]="googlekey">
-            <button mat-icon-button matSuffix [cdkCopyToClipboard]="googlekey">
-                <mat-icon>content_copy</mat-icon>
-            </button>
-        </mat-form-field>
     </div>
     <app-crm-table #formsCrmTable [data]="forms" [keyOrdering]="keyOrdering"></app-crm-table>
 </div>

--- a/frontend/src/app/components/crm/forms/forms.component.html
+++ b/frontend/src/app/components/crm/forms/forms.component.html
@@ -1,5 +1,5 @@
 <div id="content" fxLayout="column" fxLayoutAlign="center stretch" fxLayoutGap="23px">
-    <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="30px">
+    <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="30px">
         <button mat-raised-button color="primary" (click)="deleteForms()">UNLINK FORM</button>
         <mat-form-field appearance="outline" floatLabel="always">
             <mat-label>Find Form</mat-label>

--- a/frontend/src/app/components/crm/forms/forms.component.ts
+++ b/frontend/src/app/components/crm/forms/forms.component.ts
@@ -21,10 +21,11 @@ export class FormsComponent implements OnInit {
     map(res => res.forms)
   );
   keyOrdering: string[] = ['formId', 'formName', 'date'];
-  webhookUrl: string = '';
-  googlekey: string = '';
+  webhookUrl = '';
+  googlekey = '';
 
-  constructor(public dialog: MatDialog, private formService: FormService,
+  constructor(
+    public dialog: MatDialog, private formService: FormService,
     private webhookService: WebhookService, private titleService: Title) {
       this.titleService.setTitle('Forms');
   }
@@ -52,7 +53,7 @@ export class FormsComponent implements OnInit {
   deleteForms(): void {
     this.formService.unlinkForms(this.formsTable.selection.selected)
     .subscribe((_any: any) => {
-      if(this.formsTable !== undefined) {
+      if (this.formsTable !== undefined) {
         // refresh because we deleted some form rows
         this.formsTable.refreshDataSource();
       }

--- a/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.css
+++ b/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.css
@@ -2,6 +2,6 @@
     position: absolute;
     width: 0;
     height: 0;
-    bottom: 0;
+    top: 0;
     right: 0;
 }

--- a/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.css
+++ b/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.css
@@ -1,0 +1,7 @@
+#tooltip {
+    position: absolute;
+    width: 0;
+    height: 0;
+    bottom: 0;
+    right: 0;
+}

--- a/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.html
+++ b/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.html
@@ -1,0 +1,10 @@
+<mat-form-field appearance="outline" floatLabel="always">
+<mat-label>{{ label }}</mat-label>
+    <input matInput readonly="true" type="url" [value]="copyableValue">
+    <button mat-icon-button matSuffix
+        (click)="showTooltip()"
+        [cdkCopyToClipboard]="copyableValue">
+        <mat-icon>content_copy</mat-icon>
+        <div id="tooltip" #tooltip="matTooltip" matTooltip="Copied"></div>
+    </button>
+</mat-form-field>

--- a/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.html
+++ b/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.html
@@ -4,7 +4,7 @@
     <button mat-icon-button matSuffix
         (click)="showTooltip()"
         [cdkCopyToClipboard]="copyableValue">
-        <mat-icon>content_copy</mat-icon>
         <div id="tooltip" #tooltip="matTooltip" matTooltip="Copied"></div>
+        <mat-icon>content_copy</mat-icon>
     </button>
 </mat-form-field>

--- a/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.spec.ts
+++ b/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CopyableFormFieldComponent } from './copyable-form-field.component';
+
+describe('CopyableFormFieldComponent', () => {
+  let component: CopyableFormFieldComponent;
+  let fixture: ComponentFixture<CopyableFormFieldComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CopyableFormFieldComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CopyableFormFieldComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.ts
+++ b/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.ts
@@ -19,9 +19,9 @@ export class CopyableFormFieldComponent implements OnInit {
 
   showTooltip(): void {
     this.tooltip.show();
-    setTimeout(() => {
-      this.tooltip.hide();
-    }, 500);
+    // setTimeout(() => {
+    //   this.tooltip.hide();
+    // }, 500);
   }
 
 }

--- a/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.ts
+++ b/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit, Input, ViewChild } from '@angular/core';
+import { MatTooltip } from '@angular/material/tooltip';
+
+@Component({
+  selector: 'app-copyable-form-field',
+  templateUrl: './copyable-form-field.component.html',
+  styleUrls: ['./copyable-form-field.component.css']
+})
+export class CopyableFormFieldComponent implements OnInit {
+  @Input() label: string;
+  @Input() copyableValue: string;
+  tooltipMessage: string = 'Copied';
+  @ViewChild('tooltip') tooltip: MatTooltip; 
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  showTooltip(): void {
+    this.tooltip.show();
+    setTimeout(() => {
+      this.tooltip.hide();
+    }, 500);
+  }
+
+}

--- a/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.ts
+++ b/frontend/src/app/components/shared/copyable-form-field/copyable-form-field.component.ts
@@ -19,9 +19,9 @@ export class CopyableFormFieldComponent implements OnInit {
 
   showTooltip(): void {
     this.tooltip.show();
-    // setTimeout(() => {
-    //   this.tooltip.hide();
-    // }, 500);
+    setTimeout(() => {
+      this.tooltip.hide();
+    }, 500);
   }
 
 }

--- a/frontend/src/app/models/server_responses/link-form-response.model.ts
+++ b/frontend/src/app/models/server_responses/link-form-response.model.ts
@@ -1,4 +1,4 @@
 export interface LinkFormResponse {
-    form_id: string,
-    form_name: string
+    form_id: string;
+    form_name: string;
 }

--- a/frontend/src/app/services/form.service.ts
+++ b/frontend/src/app/services/form.service.ts
@@ -23,11 +23,11 @@ export class FormService {
     return this.http.get<FormsResponse>(this.formEndpoint, options)
     .pipe(
       retry(3),
-      catchError((_error: HttpErrorResponse) => {
+      catchError((error: HttpErrorResponse) => {
         // return no forms and empty webhook url
         return of<FormsResponse>({ forms: [] });
       })
-    )
+    );
   }
 
   linkForm(linkFormResponse: LinkFormResponse): Observable<WebHookResponse> {

--- a/frontend/src/app/services/login.service.ts
+++ b/frontend/src/app/services/login.service.ts
@@ -13,8 +13,8 @@ export class LoginService {
 
   loginEndpoint = '/api/login';
 
-  private handleError(_error: HttpErrorResponse) {
-    console.log("Login Service failed!")
+  private handleError(error: HttpErrorResponse) {
+    console.log('Login Service failed!');
     return of<LoginResponse>({
       url: '/',
       loggedIn: false


### PR DESCRIPTION
# Description

Added a profile button so that when you click on it, it will load a profile menu with that user's webhook, Google key, and logout button. Tooltips have been added to copy-to-clip-board buttons so that when you click on them, they will popup and disappear after half a second.
![image](https://user-images.githubusercontent.com/66025811/87583939-b7495d80-c6aa-11ea-9349-9f4c316f99e6.png)

Removed webhook and Google key from forms page.
![image](https://user-images.githubusercontent.com/66025811/87582924-20c86c80-c6a9-11ea-917f-af29e21d219a.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Manual testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
