### PR TITLE
Alex/rename forms and campaigns

### DIFF
--- a/frontend/src/app/components/crm/campaigns/campaigns.component.html
+++ b/frontend/src/app/components/crm/campaigns/campaigns.component.html
@@ -1,12 +1,3 @@
 <div id="content" fxLayout="column" fxLayoutAlign="center stretch" fxLayoutGap="23px">
-    <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="30px">
-        <mat-form-field appearance="outline" floatLabel="always">
-            <mat-label>Find Campaign</mat-label>
-            <input matInput placeholder="Campaign">
-            <button mat-icon-button matSuffix>
-                <mat-icon>search</mat-icon>
-            </button>
-        </mat-form-field>
-    </div>
     <app-crm-table #campaignsCrmTable [data]="campaigns" [keyOrdering]="keyOrdering"></app-crm-table>
 </div>

--- a/frontend/src/app/components/crm/campaigns/campaigns.component.html
+++ b/frontend/src/app/components/crm/campaigns/campaigns.component.html
@@ -1,3 +1,3 @@
 <div id="content" fxLayout="column" fxLayoutAlign="center stretch" fxLayoutGap="23px">
-    <app-crm-table #campaignsCrmTable [data]="campaigns" [keyOrdering]="keyOrdering"></app-crm-table>
+    <app-crm-table #campaignsCrmTable [data]="campaigns" [keyOrdering]="keyOrdering" (rename)=renameCampaign($event)></app-crm-table>
 </div>

--- a/frontend/src/app/components/crm/campaigns/campaigns.component.spec.ts
+++ b/frontend/src/app/components/crm/campaigns/campaigns.component.spec.ts
@@ -8,7 +8,7 @@ import { Campaign } from 'src/app/models/server_responses/campaign.model';
 describe('CampaignsComponent', () => {
   const campaignService: Partial<CampaignService> = {
     getAllCampaigns: () => of<Campaign[]>([])
-  }
+  };
   let component: CampaignsComponent;
   let fixture: ComponentFixture<CampaignsComponent>;
 

--- a/frontend/src/app/components/crm/campaigns/campaigns.component.spec.ts
+++ b/frontend/src/app/components/crm/campaigns/campaigns.component.spec.ts
@@ -1,8 +1,12 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+// import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CampaignsComponent } from './campaigns.component';
 import { CampaignsModule } from './campaigns.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { CampaignService } from 'src/app/services/campaign.service';
+import { of } from 'rxjs';
+import { Campaign } from 'src/app/models/server_responses/campaign.model';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 
 describe('CampaignsComponent', () => {
   const campaignService: Partial<CampaignService> = {
@@ -13,6 +17,10 @@ describe('CampaignsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      declarations: [ CampaignsComponent ],
+      providers: [
+        { provide: CampaignService, useValue: campaignService }
+      ],
       imports: [ CampaignsModule, NoopAnimationsModule],
     })
     .compileComponents();

--- a/frontend/src/app/components/crm/campaigns/campaigns.component.spec.ts
+++ b/frontend/src/app/components/crm/campaigns/campaigns.component.spec.ts
@@ -1,14 +1,23 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CampaignsComponent } from './campaigns.component';
+import { CampaignService } from 'src/app/services/campaign.service';
+import { of } from 'rxjs';
+import { Campaign } from 'src/app/models/server_responses/campaign.model';
 
 describe('CampaignsComponent', () => {
+  const campaignService: Partial<CampaignService> = {
+    getAllCampaigns: () => of<Campaign[]>([])
+  }
   let component: CampaignsComponent;
   let fixture: ComponentFixture<CampaignsComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CampaignsComponent ]
+      declarations: [ CampaignsComponent ],
+      providers: [
+        { provide: CampaignService, useValue: campaignService }
+      ]
     })
     .compileComponents();
   }));

--- a/frontend/src/app/components/crm/campaigns/campaigns.component.ts
+++ b/frontend/src/app/components/crm/campaigns/campaigns.component.ts
@@ -26,13 +26,10 @@ export class CampaignsComponent implements OnInit {
   /**
    * Renames the given campaign based on the id to the current name in the campaign object.
    * Called by the rename event from app-crm-table
-   * @param renamedCampaign the campaign to be renamed
+   * @param campaign the campaign to be renamed
    */
-  renameCampaign(renamedCampaign: Campaign) {
-    console.log(renamedCampaign);
-    this.campaignService.renameCampaign(renamedCampaign).subscribe(response => {
-      console.log(response);
-    });
+  renameCampaign(campaign: Campaign) {
+    this.campaignService.renameCampaign(campaign).subscribe();
   }
 
 }

--- a/frontend/src/app/components/crm/campaigns/campaigns.component.ts
+++ b/frontend/src/app/components/crm/campaigns/campaigns.component.ts
@@ -23,4 +23,16 @@ export class CampaignsComponent implements OnInit {
   ngOnInit(): void {
   }
 
+  /**
+   * Renames the given campaign based on the id to the current name in the campaign object.
+   * Called by the rename event from app-crm-table
+   * @param renamedCampaign the campaign to be renamed
+   */
+  renameCampaign(renamedCampaign: Campaign) {
+    console.log(renamedCampaign);
+    this.campaignService.renameCampaign(renamedCampaign).subscribe(response => {
+      console.log(response);
+    });
+  }
+
 }

--- a/frontend/src/app/components/crm/forms/forms.component.html
+++ b/frontend/src/app/components/crm/forms/forms.component.html
@@ -1,13 +1,6 @@
 <div id="content" fxLayout="column" fxLayoutAlign="center stretch" fxLayoutGap="23px">
     <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="30px">
         <button mat-raised-button color="primary" (click)="deleteForms()">UNLINK FORM</button>
-        <mat-form-field appearance="outline" floatLabel="always">
-            <mat-label>Find Form</mat-label>
-            <input matInput placeholder="Form 1">
-            <button mat-icon-button matSuffix>
-                <mat-icon>search</mat-icon>
-            </button>
-        </mat-form-field>
     </div>
     <app-crm-table #formsCrmTable [data]="forms" [keyOrdering]="keyOrdering"></app-crm-table>
 </div>

--- a/frontend/src/app/components/crm/forms/forms.component.html
+++ b/frontend/src/app/components/crm/forms/forms.component.html
@@ -2,5 +2,5 @@
     <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="30px">
         <button mat-raised-button color="primary" (click)="deleteForms()">UNLINK FORM</button>
     </div>
-    <app-crm-table #formsCrmTable [data]="forms" [keyOrdering]="keyOrdering"></app-crm-table>
+    <app-crm-table #formsCrmTable [data]="forms" [keyOrdering]="keyOrdering" (rename)="renameForm($event)"></app-crm-table>
 </div>

--- a/frontend/src/app/components/crm/forms/forms.component.html
+++ b/frontend/src/app/components/crm/forms/forms.component.html
@@ -1,6 +1,3 @@
 <div id="content" fxLayout="column" fxLayoutAlign="center stretch" fxLayoutGap="23px">
-    <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="30px">
-        <button mat-raised-button color="primary" (click)="deleteForms()">UNLINK FORM</button>
-    </div>
     <app-crm-table #formsCrmTable [data]="forms" [keyOrdering]="keyOrdering" (rename)="renameForm($event)"></app-crm-table>
 </div>

--- a/frontend/src/app/components/crm/forms/forms.component.spec.ts
+++ b/frontend/src/app/components/crm/forms/forms.component.spec.ts
@@ -12,8 +12,7 @@ import { WebHookResponse } from 'src/app/models/server_responses/webhook-respons
 describe('FormsComponent', () => {
   let component: FormsComponent;
   const formService: Partial<FormService> = {
-    getForms: () => of<FormsResponse>({ forms: [] }),
-    unlinkForms: (req: Form[]) => 'ok'
+    getForms: () => of<FormsResponse>({ forms: [] })
   };
   const webhookService: Partial<WebhookService> = {
     getWebhook: () => of<WebHookResponse>({ webhookUrl: '/', googleKey: 'abc' })

--- a/frontend/src/app/components/crm/forms/forms.component.ts
+++ b/frontend/src/app/components/crm/forms/forms.component.ts
@@ -36,14 +36,4 @@ export class FormsComponent implements OnInit {
   renameForm(form: Form) {
     this.formService.renameForm(form).subscribe();
   }
-
-  deleteForms(): void {
-    this.formService.unlinkForms(this.formsTable.selection.selected)
-    .subscribe((_: any) => {
-      if (this.formsTable !== undefined) {
-        // refresh because we deleted some form rows
-        this.formsTable.refreshDataSource();
-      }
-    });
-  }
 }

--- a/frontend/src/app/components/crm/forms/forms.component.ts
+++ b/frontend/src/app/components/crm/forms/forms.component.ts
@@ -20,7 +20,7 @@ export class FormsComponent implements OnInit {
   keyOrdering: string[] = ['formId', 'formName', 'date'];
 
   constructor(
-    public dialog: MatDialog, private formService: FormService, 
+    public dialog: MatDialog, private formService: FormService,
     private titleService: Title) {
       this.titleService.setTitle('Forms');
   }

--- a/frontend/src/app/components/crm/forms/forms.component.ts
+++ b/frontend/src/app/components/crm/forms/forms.component.ts
@@ -28,6 +28,15 @@ export class FormsComponent implements OnInit {
   ngOnInit(): void {
   }
 
+  /**
+   * Renames the given form based on the id to the current name in the form object.
+   * Called by the rename event from app-crm-table
+   * @param form the form to be renamed
+   */
+  renameForm(form: Form) {
+    this.formService.renameForm(form).subscribe();
+  }
+
   deleteForms(): void {
     this.formService.unlinkForms(this.formsTable.selection.selected)
     .subscribe((_: any) => {

--- a/frontend/src/app/components/shared/crm-table/crm-table.component.css
+++ b/frontend/src/app/components/shared/crm-table/crm-table.component.css
@@ -1,3 +1,10 @@
+* {
+    box-sizing: border-box;
+}
+
+#filterFxBox {
+    padding: 5px 0px;
+}
 table {
     width: 100%;
     margin: 0 auto;

--- a/frontend/src/app/components/shared/crm-table/crm-table.component.html
+++ b/frontend/src/app/components/shared/crm-table/crm-table.component.html
@@ -32,8 +32,9 @@
                 <th mat-header-cell *matHeaderCellDef>{{ map.displayedName }}</th>
                 <td mat-cell *matCellDef="let element">
                     <mat-form-field floatLabel="never">
-                        <input matInput placeHolder={{map.displayedName}}
-                        [value]="element[map.key]">
+                        <input matInput (value)="element[map.key]"
+                            [(ngModel)]="element[map.key]"
+                            (change)="emitRename(element)">
                     </mat-form-field>
                 </td>
             </div>

--- a/frontend/src/app/components/shared/crm-table/crm-table.component.html
+++ b/frontend/src/app/components/shared/crm-table/crm-table.component.html
@@ -28,8 +28,19 @@
             </td>
         </ng-container>
         <ng-container *ngFor="let map of keyDisplayedNameOrdering" [matColumnDef]="map.key">
-            <th mat-header-cell *matHeaderCellDef>{{ map.displayedName }}</th>
-            <td mat-cell *matCellDef="let element"> {{ element[map.key] }}</td>
+            <div *ngIf="map.displayedName.indexOf('Name') > -1; else normalCell">
+                <th mat-header-cell *matHeaderCellDef>{{ map.displayedName }}</th>
+                <td mat-cell *matCellDef="let element">
+                    <mat-form-field floatLabel="never">
+                        <input matInput placeHolder={{map.displayedName}}
+                        [value]="element[map.key]">
+                    </mat-form-field>
+                </td>
+            </div>
+            <ng-template #normalCell>
+                <th mat-header-cell *matHeaderCellDef>{{ map.displayedName }}</th>
+                <td mat-cell *matCellDef="let element"> {{ element[map.key] }}</td>
+            </ng-template>
         </ng-container>
         <tr mat-header-row *matHeaderRowDef="keyOrdering"></tr>
         <tr mat-row *matRowDef="let row; columns: keyOrdering;"></tr>

--- a/frontend/src/app/components/shared/crm-table/crm-table.component.html
+++ b/frontend/src/app/components/shared/crm-table/crm-table.component.html
@@ -1,3 +1,14 @@
+<div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="30px">
+    <mat-form-field appearance="outline" floatLabel="always">
+        <mat-label>Search</mat-label>
+        <input matInput
+                (change)="applyFilter($event)"
+                placeholder="Search">
+        <button mat-icon-button matSuffix>
+            <mat-icon>search</mat-icon>
+        </button>
+    </mat-form-field>
+</div>
 <div *ngIf="dataSource.data.length > 0; else emptyMessage">
     <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
         <ng-container matColumnDef="select">

--- a/frontend/src/app/components/shared/crm-table/crm-table.component.html
+++ b/frontend/src/app/components/shared/crm-table/crm-table.component.html
@@ -1,4 +1,4 @@
-<div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="30px">
+<div id="filterFxBox" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="30px">
     <mat-form-field appearance="outline" floatLabel="always">
         <mat-label>Search</mat-label>
         <input matInput

--- a/frontend/src/app/components/shared/crm-table/crm-table.component.ts
+++ b/frontend/src/app/components/shared/crm-table/crm-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, ChangeDetectionStrategy, OnChanges, AfterContentChecked, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, Input, ChangeDetectionStrategy, OnChanges, AfterContentChecked, ChangeDetectorRef, Output, EventEmitter} from '@angular/core';
 import { TableData, KeyDisplayedNameMap } from '../../../models/component_states/table-data.model';
 import * as _ from 'lodash';
 import { MatTableDataSource } from '@angular/material/table';
@@ -14,6 +14,7 @@ export class CrmTableComponent<T> implements OnInit {
   @Input() data: Observable<T[]>;
   @Input() keyOrdering: string[] = [];
   @Input() selectionEnabled = true;
+  @Output() rename: EventEmitter<T> = new EventEmitter();
   dataSource: MatTableDataSource<T> = new MatTableDataSource<T>();
   keyDisplayedNameOrdering: KeyDisplayedNameMap[];
   public selection: SelectionModel<T> = new SelectionModel<T>(/*allow mulitselect=*/true);
@@ -39,6 +40,14 @@ export class CrmTableComponent<T> implements OnInit {
       this.dataSource.data = res;
       this.changeDectectorRef.detectChanges();
     });
+  }
+
+  /**
+   * Emits a rename change for the parent component to handle and rename the corresponding form or campaign
+   * @param renamedEntry the element that is being renamed
+   */
+  emitRename(renamedEntry: T) {
+    this.rename.emit(renamedEntry);
   }
 
 

--- a/frontend/src/app/components/shared/crm-table/crm-table.component.ts
+++ b/frontend/src/app/components/shared/crm-table/crm-table.component.ts
@@ -41,6 +41,19 @@ export class CrmTableComponent<T> implements OnInit {
     });
   }
 
+
+  /**
+   * This method will listen to the filter field in the html and update the value of dataSource
+   * @param event an input from the filter field
+   */
+  applyFilter(event: Event) {
+    const filterValue = (event.target as HTMLInputElement).value;
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+    if (this.dataSource.paginator != null) {
+      this.dataSource.paginator.firstPage();
+    }
+  }
+
   /** Whether the number of selected elements matches the total number of rows. */
   isAllSelected() {
     const numSelected = this.selection.selected.length;

--- a/frontend/src/app/services/campaign.service.ts
+++ b/frontend/src/app/services/campaign.service.ts
@@ -21,7 +21,7 @@ export class CampaignService {
   }
 
   renameCampaign(campaign: Campaign): any {
-    const body = {'campaignId': campaign.campaignId.toString(), 'campaignName': campaign.campaignName};
+    const body = {campaignId: campaign.campaignId.toString(), campaignName: campaign.campaignName};
     return this.http.put<any>(this.url, body).pipe(retry(3));
   }
 }

--- a/frontend/src/app/services/campaign.service.ts
+++ b/frontend/src/app/services/campaign.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { Campaign, CampaignsResponse} from '../models/server_responses/campaign.model';
+import { map, retry } from 'rxjs/operators';
+import { Campaign, CampaignsResponse } from '../models/server_responses/campaign.model';
 
 @Injectable({
   providedIn: 'root'
@@ -18,5 +18,12 @@ export class CampaignService {
     return this.http.get<CampaignsResponse>(this.url, options).pipe(
       map(res => res.campaigns)
     );
+  }
+
+  renameCampaign(campaign: Campaign): any {
+    const body = {'campaignId': campaign.campaignId.toString(), 'campaignName': campaign.campaignName};
+    return this.http.put<any>(this.url, body).pipe(
+      retry(3)
+    );;
   }
 }

--- a/frontend/src/app/services/campaign.service.ts
+++ b/frontend/src/app/services/campaign.service.ts
@@ -22,8 +22,6 @@ export class CampaignService {
 
   renameCampaign(campaign: Campaign): any {
     const body = {'campaignId': campaign.campaignId.toString(), 'campaignName': campaign.campaignName};
-    return this.http.put<any>(this.url, body).pipe(
-      retry(3)
-    );;
+    return this.http.put<any>(this.url, body).pipe(retry(3));
   }
 }

--- a/frontend/src/app/services/form.service.ts
+++ b/frontend/src/app/services/form.service.ts
@@ -31,6 +31,11 @@ export class FormService {
     );
   }
 
+  renameForm(form :Form): any {
+    const body = {'formId': form.formId.toString(), 'formName': form.formName};
+    return this.http.put<any>(this.formEndpoint, body).pipe(retry(3));
+  }
+
   unlinkForms(formsToUnlink: Form[]): any {
     const formIds = formsToUnlink.map((form: Form) => form.formId);
     let httpParams: HttpParams = new HttpParams();

--- a/frontend/src/app/services/form.service.ts
+++ b/frontend/src/app/services/form.service.ts
@@ -1,9 +1,7 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { FormsResponse } from '../models/server_responses/forms-response.model';
-import { LinkFormRequest } from '../models/server_requests/link-form-request.model';
-import { WebHookResponse } from '../models/server_responses/webhook-response.model';
 import { retry, catchError, first } from 'rxjs/operators';
 import { Form } from '../models/server_responses/forms-response.model';
 

--- a/frontend/src/app/services/form.service.ts
+++ b/frontend/src/app/services/form.service.ts
@@ -29,8 +29,8 @@ export class FormService {
     );
   }
 
-  renameForm(form :Form): any {
-    const body = {'formId': form.formId.toString(), 'formName': form.formName};
+  renameForm(form: Form): any {
+    const body = {formId: form.formId.toString(), formName: form.formName};
     return this.http.put<any>(this.formEndpoint, body).pipe(retry(3));
   }
 }

--- a/frontend/src/app/services/form.service.ts
+++ b/frontend/src/app/services/form.service.ts
@@ -35,17 +35,4 @@ export class FormService {
     const body = {'formId': form.formId.toString(), 'formName': form.formName};
     return this.http.put<any>(this.formEndpoint, body).pipe(retry(3));
   }
-
-  unlinkForms(formsToUnlink: Form[]): any {
-    const formIds = formsToUnlink.map((form: Form) => form.formId);
-    let httpParams: HttpParams = new HttpParams();
-    formIds.forEach((formId: number) => {
-      httpParams = httpParams.append('formIds[]', formId.toString());
-    });
-    const options = {
-      responseType: 'json' as const,
-      params: httpParams
-    };
-    return this.http.delete<any>(this.formEndpoint, options).pipe(first());
-  }
 }


### PR DESCRIPTION
## Description

Adds the feature to rename forms and campaigns in their respective tables utilizing the app-crm-table (currently any columns containing "Name" are set to be editable and throw the "rename" event on change).
Makes the search button on both the forms and campaigns page usable.
Removes the unlink form button and feature from the front end.

![image](https://user-images.githubusercontent.com/22645489/87990629-64a8e080-cab2-11ea-80e7-56c646de9421.png)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually on local dev server

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings