### PR TITLE
Allow Google Maps API key to be commited

### DIFF
--- a/.gitallow
+++ b/.gitallow
@@ -1,0 +1,1 @@
+maps\/api\/js\?key


### PR DESCRIPTION
## Description

if you tried to commit, you would get an error saying that you can't commit because of an exposed API key. We will allow this key since it is meant to be [public](https://stackoverflow.com/a/1364883)
![image](https://user-images.githubusercontent.com/66025811/88217603-cc833680-cc2c-11ea-9388-d62fa1a03623.png)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
