### PR TITLE
Make sidenav buttons fully clickable

### DIFF
--- a/frontend/src/app/components/crm/crm.component.html
+++ b/frontend/src/app/components/crm/crm.component.html
@@ -21,7 +21,7 @@
       <mat-divider></mat-divider>
       <!-- Button to toggle text in sidebar. -->
       <mat-list-item (click)="isExpanded = !isExpanded" >
-        <button color="primary" mat-button disableRipple>
+        <button color="primary" mat-button disableRipple class="no-hover-effect">
           <mat-icon mat-list-icon color="primary">{{ isExpanded ? "chevron_left" : "chevron_right" }}</mat-icon>
           <span i18n *ngIf="isExpanded" class="mat-h4">Hide</span>
         </button>

--- a/frontend/src/app/components/crm/crm.component.html
+++ b/frontend/src/app/components/crm/crm.component.html
@@ -13,7 +13,7 @@
       <mat-divider></mat-divider>
       <!-- All the buttons that lead to different pages of the CRM -->
       <a mat-list-item *ngFor="let datum of navigationData" [routerLink]="datum.link">
-        <button color="primary" mat-button>
+        <button mat-button color="primary" class="no-hover-effect">
           <mat-icon mat-list-icon color="primary">{{ datum.icon }}</mat-icon>
           <span *ngIf="isExpanded" class="mat-h4">{{ datum.displayedName }}</span>
         </button>

--- a/frontend/src/app/components/crm/crm.component.html
+++ b/frontend/src/app/components/crm/crm.component.html
@@ -12,12 +12,12 @@
       </mat-list-item>
       <mat-divider></mat-divider>
       <!-- All the buttons that lead to different pages of the CRM -->
-      <mat-list-item *ngFor="let datum of navigationData">
-        <button color="primary" mat-button [routerLink]="datum.link">
+      <a mat-list-item *ngFor="let datum of navigationData" [routerLink]="datum.link">
+        <button color="primary" mat-button>
           <mat-icon mat-list-icon color="primary">{{ datum.icon }}</mat-icon>
           <span *ngIf="isExpanded" class="mat-h4">{{ datum.displayedName }}</span>
         </button>
-      </mat-list-item>
+      </a>
       <mat-divider></mat-divider>
       <!-- Button to toggle text in sidebar. -->
       <mat-list-item (click)="isExpanded = !isExpanded" >

--- a/frontend/src/app/components/crm/crm.component.html
+++ b/frontend/src/app/components/crm/crm.component.html
@@ -5,7 +5,7 @@
       <!-- Sidebar title to let user know this is miniCRM -->
       <mat-list-item>
         <!-- Using button to keep spacing consistent -->
-        <button mat-button>
+        <button mat-button class="no-hover-effect" disableRipple>
           <mat-icon mat-list-icon>layers</mat-icon>
           <span *ngIf="isExpanded" class="mat-h2">miniCRM</span>
         </button>
@@ -13,7 +13,7 @@
       <mat-divider></mat-divider>
       <!-- All the buttons that lead to different pages of the CRM -->
       <a mat-list-item *ngFor="let datum of navigationData" [routerLink]="datum.link">
-        <button mat-button color="primary" class="no-hover-effect">
+        <button mat-button disableRipple color="primary" class="no-hover-effect">
           <mat-icon mat-list-icon color="primary">{{ datum.icon }}</mat-icon>
           <span *ngIf="isExpanded" class="mat-h4">{{ datum.displayedName }}</span>
         </button>
@@ -21,7 +21,7 @@
       <mat-divider></mat-divider>
       <!-- Button to toggle text in sidebar. -->
       <mat-list-item (click)="isExpanded = !isExpanded" >
-        <button color="primary" mat-button>
+        <button color="primary" mat-button disableRipple>
           <mat-icon mat-list-icon color="primary">{{ isExpanded ? "chevron_left" : "chevron_right" }}</mat-icon>
           <span i18n *ngIf="isExpanded" class="mat-h4">Hide</span>
         </button>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -12,3 +12,7 @@ body {
 .mat-form-field-wrapper {
     padding-bottom: 0;
 }
+
+.no-hover-effect.mat-button .mat-button-focus-overlay {
+    background-color: transparent !important;
+}


### PR DESCRIPTION
## Description
Addresses issue #67 that the side nav buttons aren't fully clickable.
Also updates the shading on hover and click so that there aren't two boxes as shown below:
![image](https://user-images.githubusercontent.com/22645489/88606761-89213180-d04b-11ea-8b72-418c4139b1e5.png)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually and with existing unit tests

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings